### PR TITLE
Preserve double dollar signs in script block

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = ({ filter } = {}) => {
 
       content = content
         .replace(/<script[\s\S]*<\/script>/, (s) => {
-          scriptBlock = s;
+          scriptBlock = s.replace(/\$\$/g, "$$$$$");
           scriptMark = `<!--${Math.random()}${Math.random()}${Math.random()}${Math.random()}-->`;
           return scriptMark;
         })


### PR DESCRIPTION
Double dollar signs (most used with ```$$slots``` in Svelte component script) have special meanings in Javascript String.prototype.replace(), so use five dollar signs to preserve the original dollar sign counts

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_a_parameter